### PR TITLE
Revert "Remove flags getting specified twice"

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@
 #--------------------------------
 OBJ=obj
 SRC=.
+CPPFLAGS:=$(shell dpkg-buildflags --get CPPFLAGS)
 CFLAGS:=$(shell dpkg-buildflags --get CFLAGS)
 LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
@@ -15,7 +16,7 @@ objs = $(OBJ)/jhead.o $(OBJ)/jpgfile.o $(OBJ)/jpgqguess.o $(OBJ)/paths.o \
 	$(OBJ)/exif.o $(OBJ)/iptc.o $(OBJ)/gpsinfo.o $(OBJ)/makernote.o 
 
 $(OBJ)/%.o:$(SRC)/%.c
-	${CC} $(CFLAGS) -c $< -o $@
+	${CC} $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 jhead: $(objs) jhead.h
 	${CC} $(LDFLAGS) -o jhead $(objs) -lm


### PR DESCRIPTION
This reverts commit d0b87dba6c97484c0fbb6436e26005a49379c91f.

CPPFLAGS aren't C++ flags, they're C pre-processor flags; with
dpkg-buildflags these include -D_FORTIFY_SOURCE=2 which is a shame to
do without.

Signed-off-by: Stephen Kitt <steve@sk2.org>