### PR TITLE
makefile: improve install target

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,18 +1,28 @@
 #--------------------------------
 # jhead makefile for Unix
 #--------------------------------
+PREFIX=$(DESTDIR)/usr/local
+BINDIR=$(PREFIX)/bin
+DOCDIR=$(PREFIX)/share/doc/jhead
+MANDIR=$(PREFIX)/share/man/man1
 OBJ=obj
 SRC=.
 
+DPKG_BUILDFLAGS := $(shell command -v dpkg-buildflags 2> /dev/null)
+ifdef DPKG_BUILDFLAGS
 CFLAGS:=$(shell dpkg-buildflags --get CFLAGS)
 LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
+endif
 
-# To enable electric fence:
-#CFLAGS:=$(shell dpkg-buildflags --get CFLAGS) -fsanitize=address
-#LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS) -fsanitize=address
-
+# To enable electric fence, set ELECTRIC_FENCE=1
+ifeq ($(ELECTRIC_FENCE),1)
+CFLAGS += -fsanitize=address
+LDFLAGS += -fsanitize=address
+endif
 
 all: objdir jhead
+
+docs = $(SRC)/usage.html
 
 objdir:
 	@mkdir -p obj
@@ -20,7 +30,7 @@ objdir:
 objs = $(OBJ)/jhead.o $(OBJ)/jpgfile.o $(OBJ)/jpgqguess.o $(OBJ)/paths.o \
 	$(OBJ)/exif.o $(OBJ)/iptc.o $(OBJ)/gpsinfo.o $(OBJ)/makernote.o
 
-$(OBJ)/%.o:$(SRC)/%.c 
+$(OBJ)/%.o:$(SRC)/%.c
 	${CC} $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 jhead: $(objs) jhead.h
@@ -29,6 +39,8 @@ jhead: $(objs) jhead.h
 clean:
 	rm -f $(objs) jhead
 
-install:
-	mkdir -p ${DESTDIR}/usr/bin/
-	cp jhead ${DESTDIR}/usr/bin/
+install: all
+	install -d $(BINDIR) $(DOCDIR) $(MANDIR)
+	install -m 0755 jhead $(BINDIR)
+	install -m 0644 $(docs) $(DOCDIR)
+	install -m 0644 jhead.1 $(MANDIR)


### PR DESCRIPTION
This PR adds the `usage.html` and manpage into the `install` target. It also defines several variables (`PREFIX` and friends) to allow for greater customization of where things go.

The `install` target itself has been modified to build `all` if necessary - this allows for a single `make install` to build and install if preferred. It also uses `install` instead of `mkdir`/`cp`, some of the differences/benefits of which are described in [this StackOverflow thread](https://unix.stackexchange.com/questions/104982/why-use-install-rather-than-cp-and-mkdir).

The calls to `dpkg-buildflags` are now wrapped in a conditional check to ensure the command exists. This allows the makefile to be used on environments that aren't Debian/Ubuntu-based (e.g. Arch Linux, Fedora, macOS...).

Lastly, Electric Fence can be enabled at the command line with `ELECTRIC_FENCE=1` rather than requiring the makefile to be edited (although that could still be achieved, by simply setting the variable in the makefile itself).