### PR TITLE
Fix -da usage typo & convert to UTF-8

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -132,15 +132,15 @@ or Mac OS-X won't do anything for you - you have to <b>use it from the Command p
     <b>Some of the more useful arguments for strftime are:</b>
 
     <table>
-    <tr><td>%d &nbsp </td><td>Day of month as decimal number (01 – 31)
-    <tr><td>%H</td><td>Hour in 24-hour format (00 – 23)
-    <tr><td>%j</td><td>Day of year as decimal number (001 – 366)
-    <tr><td>%m</td><td>Month as decimal number (01 – 12)
-    <tr><td>%M</td><td>Minute as decimal number (00 – 59)
-    <tr><td>%S</td><td>Second as decimal number (00 – 59)
-    <tr><td>%U</td><td>Week of year as decimal number, with Sunday as first day of week (00 – 53)
-    <tr><td>%w</td><td>Weekday as decimal number (0 – 6; Sunday is 0)
-    <tr><td>%y</td><td>Year without century, as decimal number (00 – 99)
+    <tr><td>%d &nbsp </td><td>Day of month as decimal number (01 â€“ 31)
+    <tr><td>%H</td><td>Hour in 24-hour format (00 â€“ 23)
+    <tr><td>%j</td><td>Day of year as decimal number (001 â€“ 366)
+    <tr><td>%m</td><td>Month as decimal number (01 â€“ 12)
+    <tr><td>%M</td><td>Minute as decimal number (00 â€“ 59)
+    <tr><td>%S</td><td>Second as decimal number (00 â€“ 59)
+    <tr><td>%U</td><td>Week of year as decimal number, with Sunday as first day of week (00 â€“ 53)
+    <tr><td>%w</td><td>Weekday as decimal number (0 â€“ 6; Sunday is 0)
+    <tr><td>%y</td><td>Year without century, as decimal number (00 â€“ 99)
     <tr><td>%Y</td><td>Year with century, as decimal number
     </table>
     <p>
@@ -190,7 +190,7 @@ or Mac OS-X won't do anything for you - you have to <b>use it from the Command p
     how many days the timestamp needs to be adjusted by, including leap years and daylight
     savings time changes.
     The dates are specified as yyyy:mm:dd.  For sub-day adjustments, a time of day can also
-    be included, by specifying yyyy:nn:dd/hh:mm or yyyy:mm:dd/hh:mm:ss
+    be included, by specifying yyyy:mm:dd/hh:mm or yyyy:mm:dd/hh:mm:ss
     <p>
     Examples:<br>
     Year on camera was set to 2004 instead of 2005 for pictures taken in April


### PR DESCRIPTION
Fix -da usage example to be yyyy:mm:dd/hh:mm instead of yyyy:nn:dd/hh:mm 
Github is also forcing an encoding conversion from windows-1252 to UTF-8 for this file.