### PR TITLE
makefile: add missing 'objdir' dependency for all object files

### DIFF
--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ objdir:
 objs = $(OBJ)/jhead.o $(OBJ)/jpgfile.o $(OBJ)/jpgqguess.o $(OBJ)/paths.o \
 	$(OBJ)/exif.o $(OBJ)/iptc.o $(OBJ)/gpsinfo.o $(OBJ)/makernote.o
 
-$(OBJ)/%.o:$(SRC)/%.c
+$(OBJ)/%.o:$(SRC)/%.c objdir
 	${CC} $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 jhead: $(objs) jhead.h


### PR DESCRIPTION
Without the change `make --shuffle` build fails occasionally as:

    $ make --shuffle
    gcc -O3  -c makernote.c -o obj/makernote.o
    Assembler messages:
    Fatal error: can't create obj/makernote.o: No such file or directory
    make: *** [makefile:34: obj/makernote.o] Error 1 shuffle=2306617614

Before the change build was failing every second time. After the change rebuild survived 30 times.