### PR TITLE
Fix buffer overflow in FileEditComment

### DIFF
--- a/jhead.c
+++ b/jhead.c
@@ -141,7 +141,7 @@ static int FileEditComment(char * TempFileName, char * Comment, int CommentSize)
 {
     FILE * file;
     int a;
-    char QuotedPath[PATH_MAX+10];
+    char QuotedPath[2*PATH_MAX+10];
 
     file = fopen(TempFileName, "w");
     if (file == NULL){
@@ -175,7 +175,11 @@ static int FileEditComment(char * TempFileName, char * Comment, int CommentSize)
             ErrFatal("Editor has invalid characters");
         }
 
-        sprintf(QuotedPath, "%s \"%s\"",Editor, TempFileName);
+        int num = snprintf(QuotedPath, sizeof(QuotedPath), "%s \"%s\"",Editor, TempFileName);
+        if(num > sizeof(QuotedPath)) {
+            ErrFatal("Quoted path to edit would be too long");
+        }
+
         a = system(QuotedPath);
     }
 


### PR DESCRIPTION
# Details

In the function FileEditComment in jhead.c, it is possible to trigger a buffer write overflow ([CWE-787](https://cwe.mitre.org/data/definitions/787.html)) by using a specially crafted EDITOR environment variable and JPEG filename. 

# System Info

I have replicated this overflow with the following compilers:

gcc (Ubuntu 9.4.0-1ubuntu1\~20.04.1) 9.4.0
clang version 10.0.0-4ubuntu1
Apple clang version 14.0.0 (clang-1400.0.29.202)

# Verification

The details to replicate the overflow will vary depending on your system; on Linux, PATH_MAX is typically 4096, so first set the EDITOR variable to a string of around that length:
```
export EDITOR=`python3 -c "print('A'*4096)"`
```
On MacOS X, PATH_MAX is 1024, and that should be the length used for the EDITOR variable. Next, create a JPEG with a long filename, but still within the size of PATH_MAX:
```
cp test.jpg `python -c "print(('A'*232)+'.jpg')"`
```

Then, call jhead with the `-ce` command on that JPEG to trigger the overflow:
```
$ ./jhead -ce -v AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.jpg
...[snip]
==19454==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffeefde2d2a at pc 0x00000043b967 bp 0x7ffeefde1c00 sp 0x7ffeefde1398
WRITE of size 4352 at 0x7ffeefde2d2a thread T0
    #0 0x43b966 in vsprintf (/home/dev/jhead/jhead+0x43b966)
    #1 0x43c8f3 in sprintf (/home/dev/jhead/jhead+0x43c8f3)
    #2 0x4cb017 in FileEditComment /home/dev/jhead/jhead.c:169:9
    #3 0x4c7cb9 in ProcessFile /home/dev/jhead/jhead.c:1075:31
    #4 0x4c634d in main /home/dev/jhead/jhead.c:1770:13
    #5 0x7f7929afc082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
    #6 0x41c97d in _start (/home/dev/jhead/jhead+0x41c97d)

Address 0x7ffeefde2d2a is located in stack of thread T0 at offset 4138 in frame
    #0 0x4cadcf in FileEditComment /home/dev/jhead/jhead.c:141

  This frame has 1 object(s):
    [32, 4138) 'QuotedPath' (line 144) <== Memory access at offset 4138 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/home/dev/jhead/jhead+0x43b966) in vsprintf
Shadow bytes around the buggy address:
  0x10005dfb4550: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dfb4560: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dfb4570: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dfb4580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dfb4590: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10005dfb45a0: 00 00 00 00 00[02]f3 f3 f3 f3 f3 f3 f3 f3 f3 f3
  0x10005dfb45b0: f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3
  0x10005dfb45c0: f3 f3 f3 f3 f3 f3 f3 f3 00 00 00 00 00 00 00 00
  0x10005dfb45d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dfb45e0: f1 f1 f1 f1 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x10005dfb45f0: f8 f8 f8 f8 f8 f8 f2 f2 f2 f2 f2 f2 f2 f2 f8 f8
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==19454==ABORTING
```

# Fix

Replacing the call to `sprintf` with one to `snprintf` is enough to remove the overflow. The return value from `snprintf` should be checked as well to ensure that the quoted path is valid, and an error returned if not. This pull request fixes the issue.