### PR TITLE
Fix issue #79

### DIFF
--- a/exif.c
+++ b/exif.c
@@ -1234,6 +1234,19 @@ void create_EXIF(void)
 }
 
 //--------------------------------------------------------------------------
+// Check the range of the memory block pointed by ptr contains OrientationPtr or not.
+// Return 1 if contains at least one OrientationPtr
+//--------------------------------------------------------------------------
+
+int CheckOrientationPtrs(unsigned char * ptr, unsigned int range){
+    if((OrientationPtr[0] >= (void *)ptr) && (OrientationPtr[0] < (void *)ptr+range))
+        return 1;
+    if((OrientationPtr[1] >= (void *)ptr) && (OrientationPtr[1] < (void *)ptr+range))
+        return 1;
+    return 0;
+}
+
+//--------------------------------------------------------------------------
 // Clear the rotation tag in the exif header to 1.
 // Returns NULL if no orientation tag exists.
 //--------------------------------------------------------------------------

--- a/jhead.h
+++ b/jhead.h
@@ -166,6 +166,7 @@ void Clear_EXIF();
 int process_EXIF (unsigned char * CharBuf, int length);
 void ShowImageInfo(int ShowFileInfo);
 void ShowConciseImageInfo(void);
+int CheckOrientationPtrs(unsigned char * ptr, unsigned int range);
 const char * ClearOrientation(void);
 void PrintFormatNumber(void * ValuePtr, int Format, int ByteCount);
 double ConvertAnyFormat(void * ValuePtr, int Format);

--- a/jpgfile.c
+++ b/jpgfile.c
@@ -483,7 +483,9 @@ int ReplaceThumbnail(const char * ThumbFileName)
              return FALSE;
         }
 
-        ThumbLen = 0;
+        ThumbLen = 0;
+
+
         ThumbnailFile = NULL;
     }
 
@@ -538,7 +540,7 @@ void DiscardAllButExif(void)
             CommentKeeper = Sections[a];
         }else if (Sections[a].Type == M_IPTC && IptcKeeper.Type == 0){
             IptcKeeper = Sections[a];
-        }else{
+        }else if (CheckOrientationPtrs(Sections[a].Data, Sections[a].Size+20) == 0){
             free(Sections[a].Data);
         }
     }


### PR DESCRIPTION
# Summary
fix the heap UAF problem caused by free(Sections[a].Data) by adding a check called CheckOrientationPtrs()

# Test with the Poc
```
jhead-new/jhead -norot Poc_SQ187_jhead_test.jpg

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Suspicious offset of first Exif IFD value

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Illegally sized Exif subdirectory (12336 entries)

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Bad components count 30303030

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Undefined rotation value 1291856384 in Exif

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Bad components count 30303030

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Bad components count 30303030

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Bad components count 30303030

Nonfatal Error : 'Poc_SQ187_jhead_test.jpg' Illegal subdirectory link in Exif header
Modified: Poc_SQ187_jhead_test.jpg
```